### PR TITLE
fixed indentation. added js to clear form on unload for security.

### DIFF
--- a/html/form.php
+++ b/html/form.php
@@ -1,5 +1,5 @@
 <?php defined('_DIRECT_ACCESS_CHECK') or exit(); ?>
-    <body>
+    <body onUnload="document.getElementById('secret').value = ''">
         <div id="form-div">
             <form class="form-horizontal" action=index.php method=POST>
                 <fieldset>
@@ -9,7 +9,7 @@
                             <label style="font-family: 'Enriqueta', arial, serif; line-height: 1.25; margin: 0 0 10px; font-size: 15px; font-weight: bold;"><?php echo $message_subtitle; ?></label>
                         </div>
                         <div style="margin-top:10px">
-                            <textarea class="form-control" name="secret" placeholder="Secret text..."><?php echo $template_text ?></textarea>
+                            <textarea class="form-control" id="secret" name="secret" placeholder="Secret text..."><?php echo $template_text ?></textarea>
                         </div>
                     </div>
                     <div style="margin-top: 1%; width: 100%">

--- a/index.php
+++ b/index.php
@@ -1,4 +1,6 @@
 <?php
+	#Settings
+	define('RETURN_FULL_URL', false);
 
 	define('_DIRECT_ACCESS_CHECK', 1);
 	require_once "includes/functions.php";
@@ -28,7 +30,12 @@
 			$incoming_text = $_POST['secret'];
 			$k = store_secret($incoming_text);
 		
-			$message = $_SERVER['REQUEST_SCHEME'] . "://" . $_SERVER['HTTP_HOST'] . "/?k=" . $k;
+			if ($RETURN_FULL_URL) {
+				$message = $_SERVER['REQUEST_SCHEME'] . "://" . $_SERVER['HTTP_HOST'] . "/?k=" . $k;
+			} else {
+				$message = $k;
+			}
+
 			$message_title = "Self-Destructing URL";
 			$message_subtitle = "";
 			
@@ -45,11 +52,11 @@
 		$template_text = "";
         
         	try {
-			if (isset($_GET['t']) && $_GET['t'] != "") {
-				$template_text = read_file('templates/' . basename($_GET['t'] . '.txt'));
+				if (isset($_GET['t']) && $_GET['t'] != "") {
+					$template_text = read_file('templates/' . basename($_GET['t'] . '.txt'));
 	    		}
         	} catch (Exception $e) {
-			die("Template can not be found!");
+				die("Template can not be found!");
        		}
 
 		$message_title = "Self-Destructing Message";

--- a/index.php
+++ b/index.php
@@ -50,13 +50,13 @@
       
 		#Get template from URL (if any)
 		$template_text = "";
-        
-        	try {
-				if (isset($_GET['t']) && $_GET['t'] != "") {
-					$template_text = read_file('templates/' . basename($_GET['t'] . '.txt'));
-	    		}
+
+		try {
+			if (isset($_GET['t']) && $_GET['t'] != "") {
+				$template_text = read_file('templates/' . basename($_GET['t'] . '.txt'));
+			}
         	} catch (Exception $e) {
-				die("Template can not be found!");
+			die("Template can not be found!");
        		}
 
 		$message_title = "Self-Destructing Message";

--- a/index.php
+++ b/index.php
@@ -30,7 +30,7 @@
 			$incoming_text = $_POST['secret'];
 			$k = store_secret($incoming_text);
 		
-			if ($RETURN_FULL_URL) {
+			if (constant("RETURN_FULL_URL") == true) {
 				$message = $_SERVER['REQUEST_SCHEME'] . "://" . $_SERVER['HTTP_HOST'] . "/?k=" . $k;
 			} else {
 				$message = $k;

--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <?php
 	#Settings
-	define('RETURN_FULL_URL', false);
+	define('RETURN_FULL_URL', true);
 
 	define('_DIRECT_ACCESS_CHECK', 1);
 	require_once "includes/functions.php";


### PR DESCRIPTION
JS will now clear the form when leaving the page. This will prevent someone from revealing the secret after submission by clicking browser back button or re-opening the tab.

Can now choose to show full url of secret following submission or only the 'k' value of the url. This prevents end-users from clicking the secret link (and destroying the secret) out of curiosity. 