### PR TITLE
SQLite Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ https://flashpaper.io
 ![Picture of Main Page](https://i.imgur.com/3gDOy5l.png)
 
 ## Requirements
-* PHP 5.5.0+
+* PHP 5.6+
 * Web server
 * Linux
 
@@ -26,30 +26,27 @@ To further increase security, disable access logging in your web server's config
 
 ## Summary Of How It Works
 ### Submitting Secret
-* `secrets.sqlite` sqlite database created (if it doesn't already exist) with two tables: `salts` and `secrets`.
+* `secrets.sqlite` sqlite database created (if it doesn't already exist).
 * Random 256-bit AES key is created
 * Random 128-bit IV is created
-* Random 64-bit salt is created
-* Random 128-bit salt ID is created
-* AES key is hashed with bcrypt (cost of 11). Random salt is used.
+* Random 64-bit ID is created
+* ID + AES key is hashed with bcrypt 
 * Submitted text is encrypted with AES-256-CBC using AES key and random IV
 * Ciphertext is now encrypted with AES-256-CBC using static AES key and random IV
-* Salt ID and AES key joined (known as `k`)
-* Salt ID and salt stored in `salts` table in DB
-* bcrypt hash, IV, and ciphertext stored in `secrets` table in DB
+* ID and AES key joined (known as `k`)
+* ID, IV, bcrypt hash, and ciphertext stored in in DB
 * `k` value returned to user in one-time URL
   * Example URL: `https://flashpaper.io/?k=1a2b3c4d5a6b7c8d9a0b1c2d3a4b5c6d7e8f9g`
 
  
 ### Retrieving Secret
 * `k` value removed from URL and base64 decoded
-* Decoded `k` value split into two parts: salt ID and AES key
-* Salt looked up from `salts` table in DB using salt ID from `k`
-* AES key from `k` hashed with bcrypt (cost of 11). Salt from DB is used.
-* bcrypt output used to look up ciphertext and IV from `secrets` table in DB
+* Decoded `k` value split into two parts: ID and AES key
+* IV, bcrypt hash, and ciphertext looked up from DB with ID from `k`
+* `k` bcrypt hash compared against bcrypt hash from DB (prevents tampering of URL)
 * Ciphertext decrypted with static AES key and IV
 * Ciphertext decrypted with AES key from `k` and IV
-* Salt, salt ID, bcrypt hash, ciphertext, and IV all deleted from DB
+* Entry deleted from DB
 * Decrypted text sent to user
 
 ## Automating Requests With `curl`

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To further increase security, disable access logging in your web server's config
 * Submitted text is encrypted with AES-256-CBC using AES key and random IV
 * Ciphertext is now encrypted with AES-256-CBC using static AES key and random IV
 * ID and AES key joined (known as `k`)
-* ID, IV, bcrypt hash, and ciphertext stored in in DB
+* ID, IV, bcrypt hash, and ciphertext stored in DB
 * `k` value returned to user in one-time URL
   * Example URL: `https://flashpaper.io/?k=1a2b3c4d5a6b7c8d9a0b1c2d3a4b5c6d7e8f9g`
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ To further increase security, disable access logging in your web server's config
 ### Submitting Secret
 * `secrets.sqlite` sqlite database created (if it doesn't already exist) with two tables: `salts` and `secrets`.
 * Random 256-bit AES key is created
-* Random 16-bit IV is created
+* Random 128-bit IV is created
 * Random 64-bit salt is created
-* Random 16-bit salt ID is created
+* Random 128-bit salt ID is created
 * AES key is hashed with bcrypt (cost of 11). Random salt is used.
 * Submitted text is encrypted with AES-256-CBC using AES key and random IV
 * Ciphertext is now encrypted with AES-256-CBC using static AES key and random IV

--- a/html/footer.php
+++ b/html/footer.php
@@ -1,7 +1,7 @@
 <?php defined('_DIRECT_ACCESS_CHECK') or exit(); ?>
 	<footer style="position: absolute; bottom: 0; width: 100%; height: 30px; line-height: 30px; background-color: #f5f5f5;">
 		<div class="container">
-			<span class="text-muted small">Source code for FlashPapaer is freely available at <a href="https://github.com/AndrewPaglusch/FlashPaper">Github.com</a></span>
+			<span class="text-muted small">Source code for FlashPaper is freely available at <a href="https://github.com/AndrewPaglusch/FlashPaper">Github.com</a></span>
 		</div>
 	</footer>
 </html>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2,7 +2,8 @@
 
 	defined('_DIRECT_ACCESS_CHECK') or exit();
 
-	$bcrypt_options = ['cost' => 11, 'salt' => base64_decode('6bDvAudGJKkTweOWIlxVbTWjmj/8kDL9giAPkGDN7qhCi+jM50eS/2ijplJ1jf7T1+ZF1pUmtw2xlxsb0hlr3w==')];
+	$bcrypt_cost = 11;
+
 	$static_key = base64_decode('tGOrlqr/97qxQwby+uwsbReOLxTLgrMntDKX/Uj4LMy6YSSQ9Xr4DjMgKVhnUT2pZ/YFJUo/qE/xBMD5dZBF9ZBZTnPNz+Pnez1OazpoEAy2M3vE7N/kQ4tP7kA98jf+NCKqi8MLJ6hQPMPXFuciIQsKUNWc6clJ+q5GwJAxikyxy8VCnDgOEoV0u6GpVB7syrB1OlvORAWsB7wqkq2XmiZnRVJsnz/td6kBhnwPE5F7ghlncZcyXjuL86M/bFlrqtm6pH6mVLWIAeRFdH7jVdgB/ihVsnaxXXkHnY9AZEzmuk19r+IiRHIv+ft299t//ddFM5lGduwqKCJ8tfpWFQ==');
 
 	function encrypt_decrypt($encrypt, $key, $iv, $string) {
@@ -13,48 +14,54 @@
 		}
 	}
 
-	function write_file($filename, $text, $randPrefix = false) {
-		if ( $randPrefix ) {
-			$prefix = substr(str_shuffle(implode(array_merge(range('A','Z'), range('a','z'), range(0,9)))), 0, 20);
-			$filename = dirname($filename) . "/" . $prefix . "---" . basename($filename);
-		}
-		if ($fp = fopen($filename, "w")) {
-			fwrite($fp, $text);
-			fclose($fp);
-		} else {
-			throw new Exception('Unable to write secret!');
-		}
+	function connect($databaseName) {
+		$db = new PDO("sqlite:{$databaseName}");
+		$db->exec('CREATE TABLE IF NOT EXISTS "secrets" ("hash" TEXT PRIMARY KEY, "iv" TEXT, "secret" TEXT)');
+		$db->exec('CREATE TABLE IF NOT EXISTS "salts" ("id" TEXT PRIMARY KEY, "salt" TEXT)');
+		return $db;
 	}
 
-	function read_file($filename, $randPrefix = false) {
-		if ( $randPrefix ) {
-			$results = glob(dirname($filename) . '/*--' . basename($filename));
-			if ( count($results) != 1 ) {
-				throw new Exception('This secret can not be found!');
-			} else {
-				$filename = $results[0];
-			}
-		}
-		if ( file_exists($filename) && ($fp = fopen($filename, "rb")) !== false ) {
-			$str = stream_get_contents($fp);
-			fclose($fp);
-			return $str;
-		} else {
-			throw new Exception('This secret can not be found!');
-		}
+	function writeSecret($db, $hash, $iv, $secret) {
+		$statement = $db->prepare('INSERT INTO "secrets" ("hash", "iv", "secret") VALUES (:hash, :iv, :secret)');
+		$statement->bindValue(':hash', $hash);
+		$statement->bindValue(':iv', $iv);
+		$statement->bindValue(':secret', $secret);
+		$statement->execute();
 	}
 
-	function delete_file($filename, $randPrefix) {
-		if ( $randPrefix ) {
-			$results = glob(dirname($filename) . '/*--' . basename($filename));
-			if ( count($results) != 1 ) {
-				throw new Exception('Failed to delete secret!');
-			} else {
-				unlink($results[0]);
-			}
-		} else {
-			unlink($filename);
-		}
+	function writeSalt($db, $saltid, $salt) {
+		$statement = $db->prepare('INSERT INTO "salts" ("id", "salt") VALUES (:id, :salt)');
+		$statement->bindValue(':id', $saltid);
+		$statement->bindValue(':salt', $salt);
+		$statement->execute();
+	}
+
+	function readSecret($db, $hash) {
+		$statement = $db->prepare('SELECT * FROM "secrets" WHERE hash = :hash LIMIT 1');
+		$statement->bindValue(':hash', $hash);
+		$statement->execute();
+		$result = $statement->fetch(PDO::FETCH_ASSOC);
+		return $result;
+	}
+
+	function readSalt($db, $saltid) {
+		$statement = $db->prepare('SELECT * FROM "salts" WHERE id = :saltid LIMIT 1');
+		$statement->bindValue(':saltid', $saltid);
+		$statement->execute();
+		$result = $statement->fetch(PDO::FETCH_ASSOC);
+		return $result;
+	}
+
+	function deleteSecret($db, $hash) {
+		$statement = $db->prepare('DELETE FROM "secrets" WHERE hash = :hash');
+		$statement->bindValue(':hash', $hash);
+		$statement->execute();
+	}
+
+	function deleteSalt($db, $saltid) {
+		$statement = $db->prepare('DELETE FROM "salts" WHERE id = :saltid');
+		$statement->bindValue(':saltid', $saltid);
+		$statement->execute();
 	}
 
 	function random_str($len) {
@@ -72,65 +79,114 @@
 		return base64_decode(strtr($input, '-_$', '+/='));
 	}
 
-	function store_secret($text) {
-		global $bcrypt_options, $static_key;
+	function store_secret($secret) {
+		global $bcrypt_cost, $static_key;
 
-		#generate random key
-		$rand_key = random_str(32);
+		#connect to sqlite db
+		$db = connect('secrets.sqlite');
 
-		#generate random iv
+		#generate random key, iv, salt, and saltid
+		$key = random_str(32);
 		$iv = random_str(16);
+		$salt = random_str(64);
+		$saltid = random_str(16);
 
-		#base64 encode the key (for URL)
-		$base_key = base64_encode_mod($iv . $rand_key);
+		#generate hash of key
+		$secret_hash = password_hash($key, PASSWORD_BCRYPT, ['cost' => $bcrypt_cost, 'salt' => $salt]);
 
-		#encrypt text with random key
-		$enc_text = encrypt_decrypt(true, $rand_key, $iv, $text);
+		#encrypt text with key and then static key
+		$secret = encrypt_decrypt(true, $key, $iv, $secret);
+		$secret = encrypt_decrypt(true, $static_key, $iv, $secret);
 
-		#encrypt text with static key
-		$enc_text = encrypt_decrypt(true, $static_key, $iv, $enc_text);
+		#generate k value for url
+		$k = base64_encode_mod($saltid . $key);
 
-		#generate hash of key & base64 it
-		$filename = base64_encode_mod(password_hash($iv . $rand_key, PASSWORD_BCRYPT, $bcrypt_options));
+		#base64 encode the secret_hash, iv, salt, saltid, and secret for db storage
+		$secret_hash = base64_encode_mod($secret_hash);
+		$iv = base64_encode_mod($iv);
+		$salt = base64_encode_mod($salt);
+		$saltid = base64_encode_mod($saltid);
+		$secret = base64_encode_mod($secret);
 
-		#write encrypted text to disk. filename is hash of key
-		write_file("secrets/" . $filename, $enc_text, true);
+		#write secret_hash, iv, and secret to database
+		writeSecret($db, $secret_hash, $iv, $secret);
 
-		#return base64 of key
-		return $base_key;
+		#write saltid and salt to database
+		writeSalt($db, $saltid, $salt);
+
+		#close db
+		$db = null;
+
+		#base64 encode the saltID + key (for URL)
+		return $k;
 	}
 
 	function retrieve_secret($k) {
-		global $bcrypt_options, $static_key;
+		global $bcrypt_cost, $static_key;
 
-		#validate length of key - must be 48 chars (iv = 16, key = 32)
+		#connect to sqlite db
+		$db = connect('secrets.sqlite');
+
+		#validate length of k - must be 48 chars (saltid = 16, key = 32)
 		if ( strlen(base64_decode_mod($k)) != 48 ) {
 			throw new Exception('This secret can not be found!');
 		}
 
-		#decode key from url with modified base64
-		$key = substr(base64_decode_mod($k), -32);
+		#base64 decode k
+		$k = base64_decode_mod($k);
 
-		#decode iv from url
-		$iv = substr(base64_decode_mod($k), 0, 16);
+		#extract saltid from k and base64 encode it
+		$saltid = substr($k, 0, 16);
+		$saltid = base64_encode_mod($saltid);
 
-		#generate hash of key & base64 it
-		$filename = base64_encode_mod(password_hash($iv . $key, PASSWORD_BCRYPT, $bcrypt_options));
+		#look up salt with saltid
+		$saltResult = readSalt($db, $saltid);
 
-		#read file that is named same as the hash of key
-		$enc_text = read_file("secrets/" . $filename, true);
+		#throw exception if query failed
+		if ( ! $saltResult ) {
+			throw new Exception('This secret can not be found!');
+		}
 
-		#decrypt contents of file with the static key
-		$dec_text = encrypt_decrypt(false, $static_key, $iv, $enc_text);
+		#get salt from query results and base64 decode it
+		$salt = $saltResult['salt'];
+		$salt = base64_decode_mod($salt);
 
-		#decrypt contents of file with the base64 decoded key
-		$dec_text = encrypt_decrypt(false, $key, $iv, $dec_text);
+		#extract key from k
+		$key = substr($k, -32);
 
-		#delete the file from disk
-		delete_file("secrets/" . $filename, true);
+		#generate hash of iv + key & base64 encode it
+		$secret_hash = password_hash($key, PASSWORD_BCRYPT, ['cost' => $bcrypt_cost, 'salt' => $salt]);
+		$secret_hash = base64_encode_mod($secret_hash);
+
+		#read secret, hash, and iv from db
+		$db_result = readSecret($db, $secret_hash);
+
+		#throw exception if query failed
+		if ( ! $db_result ) {
+			throw new Exception('This secret can not be found!');
+		}
+
+		#get iv from query results and base64 decode it
+		$iv = $db_result['iv'];
+		$iv = base64_decode_mod($iv);
+
+		#get secret from query results and base64 decode it
+		$secret = $db_result['secret'];
+		$secret = base64_decode_mod($secret);
+
+		#decrypt secret with the static key, and then with url key
+		$secret = encrypt_decrypt(false, $static_key, $iv, $secret);
+		$secret = encrypt_decrypt(false, $key, $iv, $secret);
+
+		#delete secret and salt from db
+		deleteSecret($db, $secret_hash);
+		deleteSalt($db, $saltid);
+
+		#close db
+		$db = null;
 
 		#return decrypted text
-		return $dec_text;
+		return $secret;
 	}
 
 ?>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -12,8 +12,18 @@
 		}
 	}
 
-	function connect($databaseName) {
-		$db = new PDO("sqlite:{$databaseName}");
+	function connect() {
+		$dbName = "secrets.sqlite";
+		$results = glob("*--{$dbName}");
+
+		if ( count($results) != 1 ) {
+			$prefix = substr(str_shuffle(implode(array_merge(range('A','Z'), range('a','z'), range(0,9)))), 0, 20);
+			$dbName = "{$prefix}--{$dbName}";
+		} else {
+			$dbName = $results[0];
+		}
+
+		$db = new PDO("sqlite:{$dbName}");
 		$db->exec('CREATE TABLE IF NOT EXISTS "secrets" ("id" TEXT PRIMARY KEY, "iv" TEXT, "hash" TEXT, "secret" TEXT)');
 		return $db;
 	}
@@ -60,7 +70,7 @@
 		global $staticKey;
 
 		#connect to sqlite db
-		$db = connect('secrets.sqlite');
+		$db = connect();
 
 		#generate random id, iv, key
 		$id = random_str(8);
@@ -96,7 +106,7 @@
 		global $staticKey;
 
 		#connect to sqlite db
-		$db = connect('secrets.sqlite');
+		$db = connect();
 
 		#validate length of k - must be 40 chars (id = 8, key = 32)
 		if ( strlen(base64_decode_mod($k)) != 40 ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -36,31 +36,17 @@
 		$statement->execute();
 	}
 
-	function readSecret($db, $hash) {
-		$statement = $db->prepare('SELECT * FROM "secrets" WHERE hash = :hash LIMIT 1');
-		$statement->bindValue(':hash', $hash);
+	function readRow($db, $table, $key, $value) {
+		$statement = $db->prepare('SELECT * FROM "' . $table . '" WHERE ' . $key . ' = :value LIMIT 1');
+		$statement->bindValue(':value', $value);
 		$statement->execute();
 		$result = $statement->fetch(PDO::FETCH_ASSOC);
 		return $result;
 	}
 
-	function readSalt($db, $saltid) {
-		$statement = $db->prepare('SELECT * FROM "salts" WHERE id = :saltid LIMIT 1');
-		$statement->bindValue(':saltid', $saltid);
-		$statement->execute();
-		$result = $statement->fetch(PDO::FETCH_ASSOC);
-		return $result;
-	}
-
-	function deleteSecret($db, $hash) {
-		$statement = $db->prepare('DELETE FROM "secrets" WHERE hash = :hash');
-		$statement->bindValue(':hash', $hash);
-		$statement->execute();
-	}
-
-	function deleteSalt($db, $saltid) {
-		$statement = $db->prepare('DELETE FROM "salts" WHERE id = :saltid');
-		$statement->bindValue(':saltid', $saltid);
+	function deleteRow($db, $table, $key, $value) {
+		$statement = $db->prepare('DELETE FROM "' . $table . '" WHERE ' . $key . ' = :value');
+		$statement->bindValue(':value', $value);
 		$statement->execute();
 	}
 
@@ -140,7 +126,7 @@
 		$saltid = base64_encode_mod($saltid);
 
 		#look up salt with saltid
-		$saltResult = readSalt($db, $saltid);
+		$saltResult = readRow($db, 'salts', 'id', $saltid);
 
 		#throw exception if query failed
 		if ( ! $saltResult ) {
@@ -159,7 +145,7 @@
 		$secret_hash = base64_encode_mod($secret_hash);
 
 		#read secret, hash, and iv from db
-		$db_result = readSecret($db, $secret_hash);
+		$db_result = readRow($db, 'secrets', 'hash', $secret_hash);
 
 		#throw exception if query failed
 		if ( ! $db_result ) {
@@ -179,8 +165,8 @@
 		$secret = encrypt_decrypt(false, $key, $iv, $secret);
 
 		#delete secret and salt from db
-		deleteSecret($db, $secret_hash);
-		deleteSalt($db, $saltid);
+		deleteRow($db, 'secrets', 'hash', $secret_hash);
+		deleteRow($db, 'salts', 'id', $saltid);
 
 		#close db
 		$db = null;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -74,7 +74,7 @@
 		#generate random key, iv, salt, and saltid
 		$key = random_str(32);
 		$iv = random_str(16);
-		$salt = random_str(64);
+		$salt = random_str(8);
 		$saltid = random_str(16);
 
 		#generate hash of key

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2,9 +2,7 @@
 
 	defined('_DIRECT_ACCESS_CHECK') or exit();
 
-	$bcrypt_cost = 11;
-
-	$static_key = base64_decode('tGOrlqr/97qxQwby+uwsbReOLxTLgrMntDKX/Uj4LMy6YSSQ9Xr4DjMgKVhnUT2pZ/YFJUo/qE/xBMD5dZBF9ZBZTnPNz+Pnez1OazpoEAy2M3vE7N/kQ4tP7kA98jf+NCKqi8MLJ6hQPMPXFuciIQsKUNWc6clJ+q5GwJAxikyxy8VCnDgOEoV0u6GpVB7syrB1OlvORAWsB7wqkq2XmiZnRVJsnz/td6kBhnwPE5F7ghlncZcyXjuL86M/bFlrqtm6pH6mVLWIAeRFdH7jVdgB/ihVsnaxXXkHnY9AZEzmuk19r+IiRHIv+ft299t//ddFM5lGduwqKCJ8tfpWFQ==');
+	$staticKey = base64_decode('tGOrlqr/97qxQwby+uwsbReOLxTLgrMntDKX/Uj4LMy6YSSQ9Xr4DjMgKVhnUT2pZ/YFJUo/qE/xBMD5dZBF9ZBZTnPNz+Pnez1OazpoEAy2M3vE7N/kQ4tP7kA98jf+NCKqi8MLJ6hQPMPXFuciIQsKUNWc6clJ+q5GwJAxikyxy8VCnDgOEoV0u6GpVB7syrB1OlvORAWsB7wqkq2XmiZnRVJsnz/td6kBhnwPE5F7ghlncZcyXjuL86M/bFlrqtm6pH6mVLWIAeRFdH7jVdgB/ihVsnaxXXkHnY9AZEzmuk19r+IiRHIv+ft299t//ddFM5lGduwqKCJ8tfpWFQ==');
 
 	function encrypt_decrypt($encrypt, $key, $iv, $string) {
 		if( $encrypt == true) {
@@ -16,157 +14,124 @@
 
 	function connect($databaseName) {
 		$db = new PDO("sqlite:{$databaseName}");
-		$db->exec('CREATE TABLE IF NOT EXISTS "secrets" ("hash" TEXT PRIMARY KEY, "iv" TEXT, "secret" TEXT)');
-		$db->exec('CREATE TABLE IF NOT EXISTS "salts" ("id" TEXT PRIMARY KEY, "salt" TEXT)');
+		$db->exec('CREATE TABLE IF NOT EXISTS "secrets" ("id" TEXT PRIMARY KEY, "iv" TEXT, "hash" TEXT, "secret" TEXT)');
 		return $db;
 	}
 
-	function writeSecret($db, $hash, $iv, $secret) {
-		$statement = $db->prepare('INSERT INTO "secrets" ("hash", "iv", "secret") VALUES (:hash, :iv, :secret)');
-		$statement->bindValue(':hash', $hash);
+	function writeSecret($db, $id, $iv, $hash, $secret) {
+		$statement = $db->prepare('INSERT INTO "secrets" ("id", "iv", "hash", "secret") VALUES (:id, :iv, :hash, :secret)');
+		$statement->bindValue(':id', $id);
 		$statement->bindValue(':iv', $iv);
+		$statement->bindValue(':hash', $hash);
 		$statement->bindValue(':secret', $secret);
 		$statement->execute();
 	}
 
-	function writeSalt($db, $saltid, $salt) {
-		$statement = $db->prepare('INSERT INTO "salts" ("id", "salt") VALUES (:id, :salt)');
-		$statement->bindValue(':id', $saltid);
-		$statement->bindValue(':salt', $salt);
-		$statement->execute();
-	}
-
-	function readRow($db, $table, $key, $value) {
-		$statement = $db->prepare('SELECT * FROM "' . $table . '" WHERE ' . $key . ' = :value LIMIT 1');
-		$statement->bindValue(':value', $value);
+	function readSecret($db, $id) {
+		$statement = $db->prepare('SELECT * FROM "secrets" WHERE id = :id LIMIT 1');
+		$statement->bindValue(':id', $id);
 		$statement->execute();
 		$result = $statement->fetch(PDO::FETCH_ASSOC);
 		return $result;
 	}
 
-	function deleteRow($db, $table, $key, $value) {
-		$statement = $db->prepare('DELETE FROM "' . $table . '" WHERE ' . $key . ' = :value');
-		$statement->bindValue(':value', $value);
+	function deleteSecret($db, $id) {
+		$statement = $db->prepare('DELETE FROM "secrets" WHERE id = :id');
+		$statement->bindValue(':id', $id);
 		$statement->execute();
 	}
 
-	function random_str($len) {
-		for ($i = -1; $i <= $len; $i++) {
+	function random_str($byteLen) {
+		for ($i = -1; $i <= $byteLen; $i++) {
 			$bytes = openssl_random_pseudo_bytes($i, $cstrong);
 		}
 		return $bytes;
 	}
 
 	function base64_encode_mod($input) {
-		return strtr(base64_encode($input), '+/=', '-_$');
+		return strtr(base64_encode($input), '+/=', '-_#');
 	}
 
 	function base64_decode_mod($input) {
-		return base64_decode(strtr($input, '-_$', '+/='));
+		return base64_decode(strtr($input, '-_#', '+/='));
 	}
 
 	function store_secret($secret) {
-		global $bcrypt_cost, $static_key;
+		global $staticKey;
 
 		#connect to sqlite db
 		$db = connect('secrets.sqlite');
 
-		#generate random key, iv, salt, and saltid
-		$key = random_str(32);
+		#generate random id, iv, key
+		$id = random_str(8);
 		$iv = random_str(16);
-		$salt = random_str(8);
-		$saltid = random_str(16);
+		$key = random_str(32);
 
-		#generate hash of key
-		$secret_hash = password_hash($key, PASSWORD_BCRYPT, ['cost' => $bcrypt_cost, 'salt' => $salt]);
+		#generate k value for url (id + key)
+		$k = base64_encode_mod($id . $key);
+
+		#generate hash of id + key
+		$hash = password_hash($id . $key, PASSWORD_BCRYPT);
 
 		#encrypt text with key and then static key
 		$secret = encrypt_decrypt(true, $key, $iv, $secret);
-		$secret = encrypt_decrypt(true, $static_key, $iv, $secret);
+		$secret = encrypt_decrypt(true, $staticKey, $iv, $secret);
 
-		#generate k value for url
-		$k = base64_encode_mod($saltid . $key);
-
-		#base64 encode the secret_hash, iv, salt, saltid, and secret for db storage
-		$secret_hash = base64_encode_mod($secret_hash);
+		#base64 encode the id, iv, and secret for db storage
+		$id = base64_encode_mod($id);
 		$iv = base64_encode_mod($iv);
-		$salt = base64_encode_mod($salt);
-		$saltid = base64_encode_mod($saltid);
 		$secret = base64_encode_mod($secret);
 
 		#write secret_hash, iv, and secret to database
-		writeSecret($db, $secret_hash, $iv, $secret);
-
-		#write saltid and salt to database
-		writeSalt($db, $saltid, $salt);
+		writeSecret($db, $id, $iv, $hash, $secret);
 
 		#close db
 		$db = null;
 
-		#base64 encode the saltID + key (for URL)
+		#return base64(id + key)
 		return $k;
 	}
 
 	function retrieve_secret($k) {
-		global $bcrypt_cost, $static_key;
+		global $staticKey;
 
 		#connect to sqlite db
 		$db = connect('secrets.sqlite');
 
-		#validate length of k - must be 48 chars (saltid = 16, key = 32)
-		if ( strlen(base64_decode_mod($k)) != 48 ) {
+		#validate length of k - must be 40 chars (id = 8, key = 32)
+		if ( strlen(base64_decode_mod($k)) != 40 ) {
 			throw new Exception('This secret can not be found!');
 		}
 
-		#base64 decode k
+		#extract key and id from k. base64 encode id
 		$k = base64_decode_mod($k);
-
-		#extract saltid from k and base64 encode it
-		$saltid = substr($k, 0, 16);
-		$saltid = base64_encode_mod($saltid);
-
-		#look up salt with saltid
-		$saltResult = readRow($db, 'salts', 'id', $saltid);
-
-		#throw exception if query failed
-		if ( ! $saltResult ) {
-			throw new Exception('This secret can not be found!');
-		}
-
-		#get salt from query results and base64 decode it
-		$salt = $saltResult['salt'];
-		$salt = base64_decode_mod($salt);
-
-		#extract key from k
 		$key = substr($k, -32);
+		$id = substr($k, 0, 8);
+		$idBase64 = base64_encode_mod($id);
 
-		#generate hash of iv + key & base64 encode it
-		$secret_hash = password_hash($key, PASSWORD_BCRYPT, ['cost' => $bcrypt_cost, 'salt' => $salt]);
-		$secret_hash = base64_encode_mod($secret_hash);
-
-		#read secret, hash, and iv from db
-		$db_result = readRow($db, 'secrets', 'hash', $secret_hash);
+		#look up secret by id
+		$secretQuery = readSecret($db, $idBase64);
 
 		#throw exception if query failed
-		if ( ! $db_result ) {
+		if ( ! $secretQuery ) {
 			throw new Exception('This secret can not be found!');
 		}
 
-		#get iv from query results and base64 decode it
-		$iv = $db_result['iv'];
-		$iv = base64_decode_mod($iv);
+		$iv = base64_decode_mod($secretQuery['iv']);
+		$hash = $secretQuery['hash'];
+		$secret = base64_decode_mod($secretQuery['secret']);
 
-		#get secret from query results and base64 decode it
-		$secret = $db_result['secret'];
-		$secret = base64_decode_mod($secret);
+		#verify hash from DB equals hash of id + key from URL
+		if ( ! password_verify($id . $key, $hash)) {
+			throw new Exception('This secret can not be found!');
+		}
 
 		#decrypt secret with the static key, and then with url key
-		$secret = encrypt_decrypt(false, $static_key, $iv, $secret);
+		$secret = encrypt_decrypt(false, $staticKey, $iv, $secret);
 		$secret = encrypt_decrypt(false, $key, $iv, $secret);
 
-		#delete secret and salt from db
-		deleteRow($db, 'secrets', 'hash', $secret_hash);
-		deleteRow($db, 'salts', 'id', $saltid);
+		#delete secret from db
+		deleteSecret($db, $idBase64);
 
 		#close db
 		$db = null;

--- a/index.php
+++ b/index.php
@@ -53,7 +53,7 @@
 
 		try {
 			if (isset($_GET['t']) && $_GET['t'] != "") {
-				$template_text = read_file('templates/' . basename($_GET['t'] . '.txt'));
+				$template_text = file_get_contents('templates/' . basename($_GET['t'] . '.txt'));
 			}
 
 			$message_title = "Self-Destructing Message";

--- a/index.php
+++ b/index.php
@@ -1,6 +1,7 @@
 <?php
 	#Settings
 	define('RETURN_FULL_URL', true);
+	define('MAX_INPUT_LENGTH', 3000);
 
 	define('_DIRECT_ACCESS_CHECK', 1);
 	require_once "includes/functions.php";
@@ -29,9 +30,14 @@
 		#**User just submitted a secret. Show them the generated URL**
 		try {
 			$incoming_text = $_POST['secret'];
+
+			if ( strlen($incoming_text) > constant('MAX_INPUT_LENGTH') ) {
+				throw new exception("Input length too long");
+			}
+
 			$k = store_secret($incoming_text);
 
-			if (constant("RETURN_FULL_URL") == true) {
+			if (constant('RETURN_FULL_URL') == true) {
 				$message = $_SERVER['REQUEST_SCHEME'] . "://" . $_SERVER['HTTP_HOST'] . "/?k=" . $k;
 			} else {
 				$message = $k;

--- a/secrets/index.php
+++ b/secrets/index.php
@@ -1,1 +1,0 @@
-<?php //Silence is golden ?>


### PR DESCRIPTION
- SQLite DB used for storage of secrets
- Secrets referenced by ID instead of bcrypt hash
- No custom bcrypt options used anymore. Let PHP take care of generating salt and figuring out cost
- Updated README