### PR TITLE
Editing the 'View Secret' button to disable on click

### DIFF
--- a/html/confirm.php
+++ b/html/confirm.php
@@ -7,7 +7,7 @@
 						<br />
 						<form method="post" action="./">
 							<input type="hidden" name="k" value="<?php echo $_GET['k'] ?>">
-							<button type="submit" class="btn btn-primary w-20 mx-auto">View Secret</button>
+							<button type="submit" onclick="this.disabled=true;this.form.submit();" class="btn btn-primary w-20 mx-auto">View Secret</button>
 						</form>
 					</div>
 				</div>


### PR DESCRIPTION
This will disable the "View Secret" button so that you can't double-click the button. Double-clicking the button causes the secret to be deleted and not viewed. 