### PR TITLE
Ensure "secure_delete" is On + maxlength on textarea

### DIFF
--- a/html/form.php
+++ b/html/form.php
@@ -8,7 +8,7 @@
 							<label style="font-family: 'Enriqueta', arial, serif; line-height: 1.25; margin: 0 0 10px; font-size: 15px; font-weight: bold;"><?php echo $message_subtitle; ?></label>
 						</div>
 						<div style="margin-top:10px">
-							<textarea class="form-control" id="secret" name="secret" rows="8" style="resize: vertical;" placeholder="Secret text..."><?php echo $template_text ?></textarea>
+							<textarea class="form-control" id="secret" name="secret" rows="8" maxlength="<?php echo constant('MAX_INPUT_LENGTH') ?>" style="resize: vertical;" placeholder="Secret text..."><?php echo $template_text ?></textarea>
 						</div>
 					</div>
 					<div class="form-group row float-right" style='padding-top: 3%'>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -101,6 +101,7 @@
 	}
 
 	function deleteSecret($db, $id) {
+		$db->exec('PRAGMA secure_delete = 1');
 		$statement = $db->prepare('DELETE FROM "secrets" WHERE id = :id');
 		$statement->bindValue(':id', $id);
 		if ( ! $statement->execute() ) {


### PR DESCRIPTION
Ensures secrets are overwritten with zeros when deleted from the database. Thanks to @Matthew-Jenkins for bringing this to my attention. More info [here](https://www.sqlite.org/pragma.html#pragma_secure_delete)

From my testing, this appears to be the default setting, but this is commit makes sure it's always set correctly.

Also adds feature requested in #32 - `maxlength` attribute on textarea