### PR TITLE
Cleaner URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To further increase security, disable access logging in your web server's config
 
 ## Summary Of How It Works
 ### Submitting Secret
-* `secrets.sqlite` sqlite database created (if it doesn't already exist).
+* `<random>--secrets.sqlite` sqlite database created (if it doesn't already exist).
 * Random 256-bit AES key is created
 * Random 256-bit AES static key is created (if one doesn't exist already)
 * Random 128-bit IV is created
@@ -34,8 +34,8 @@ To further increase security, disable access logging in your web server's config
 
  
 ### Retrieving Secret
-* `k` value removed from URL and base64 decoded
-* Decoded `k` value split into two parts: ID and AES key
+* `k` value removed from URL
+* `k` value split into two parts: ID and AES key
 * IV, bcrypt hash, and ciphertext looked up from DB with ID from `k`
 * `k` bcrypt hash compared against bcrypt hash from DB (prevents tampering of URL)
 * Ciphertext decrypted with static AES key and IV

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ https://flashpaper.io
 ![Picture of Main Page](https://i.imgur.com/3gDOy5l.png)
 
 ## Requirements
-* PHP 5.6+
+* PHP 7.0+
 * Web server
 
 ## Installation

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -146,7 +146,7 @@
 		$secret = encrypt_decrypt(true, $key, $iv, $secret);
 		$secret = encrypt_decrypt(true, getStaticKey(), $iv, $secret);
 
-		#write id, iv, bcrypt password hash, and secret (b64) to database
+		#write id, iv, bcrypt password hash, and secret to database
 		writeSecret($db, $id, $iv, $hash, $secret);
 
 		#close db

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -119,11 +119,11 @@
 
 	function crypto_rand_string($strLen) {
 		# random_int() generates cryptographically secure pseudo-random integers
-	        $chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-	        $key = '';
-	        for ($i = 0; $i < $strLen; ++$i) {
-	                $key .= $chars[random_int(0, strlen($chars) -1)];
-	        }
+		$chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+		$key = '';
+		for ($i = 0; $i < $strLen; ++$i) {
+			$key .= $chars[random_int(0, strlen($chars) -1)];
+		}
 		return $key;
 	}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -26,7 +26,7 @@
 
 		# find name of existing db or generate a new one if not found
 		if ( count($results) != 1 ) {
-			$prefix = substr(str_shuffle(implode(array_merge(range('A','Z'), range('a','z'), range(0,9)))), 0, 20);
+			$prefix = crypto_rand_string(32);
 			$dbName = "./data/{$prefix}--{$dbName}";
 		} else {
 			$dbName = $results[0];
@@ -50,7 +50,7 @@
 
 		if ( count($results) != 1 ) {
 			#static key needs to be created
-			$prefix = substr(str_shuffle(implode(array_merge(range('A','Z'), range('a','z'), range(0,9)))), 0, 20);
+			$prefix = crypto_rand_string(32);
 			$keyName = "./data/{$prefix}--{$keyName}";
 			$staticKey = random_bytes(32);
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -52,7 +52,7 @@
 			#static key needs to be created
 			$prefix = substr(str_shuffle(implode(array_merge(range('A','Z'), range('a','z'), range(0,9)))), 0, 20);
 			$keyName = "./data/{$prefix}--{$keyName}";
-			$staticKey = crypto_rand_bytes(32);
+			$staticKey = random_bytes(32);
 
 			if ( $fp = fopen($keyName, "w") ) {
 				fwrite($fp, $staticKey);
@@ -114,15 +114,6 @@
 			throw new Exception('Failed to read from database!');
 		} else {
 			return ( $verify->fetchColumn() == 0 );
-		}
-	}
-
-	function crypto_rand_bytes($byteLen) {
-		$bytes = openssl_random_pseudo_bytes($byteLen, $cstrong);
-		if ( ! $cstrong ) {
-			throw new Exception('Failed to generate cryptographically secure bytes!');
-		} else {
-			return $bytes;
 		}
 	}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -52,7 +52,7 @@
 			#static key needs to be created
 			$prefix = substr(str_shuffle(implode(array_merge(range('A','Z'), range('a','z'), range(0,9)))), 0, 20);
 			$keyName = "./data/{$prefix}--{$keyName}";
-			$staticKey = random_str(32);
+			$staticKey = crypto_rand_bytes(32);
 
 			if ( $fp = fopen($keyName, "w") ) {
 				fwrite($fp, $staticKey);
@@ -117,7 +117,7 @@
 		}
 	}
 
-	function random_str($byteLen) {
+	function crypto_rand_bytes($byteLen) {
 		$bytes = openssl_random_pseudo_bytes($byteLen, $cstrong);
 		if ( ! $cstrong ) {
 			throw new Exception('Failed to generate cryptographically secure bytes!');
@@ -126,15 +126,24 @@
 		}
 	}
 
+	function crypto_rand_string($strLen) {
+		# random_int() generates cryptographically secure pseudo-random integers
+	        $chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+	        $key = '';
+	        for ($i = 0; $i < $strLen; ++$i) {
+	                $key .= $chars[random_int(0, strlen($chars) -1)];
+	        }
+		return $key;
+	}
+
 	function store_secret($secret) {
 		#connect to sqlite db
 		$db = connect();
 
 		#generate random id, iv, key
-		$master_hash = hash('sha256', random_str(128));
-		$id = substr($master_hash, 0, 8);
-		$iv = substr($master_hash, 8, 16);
-		$key = substr($master_hash, 24, 32);
+		$id = crypto_rand_string(8);
+		$iv = crypto_rand_string(16);
+		$key = crypto_rand_string(32);
 
 		#generate k value for url (id + key)
 		$k = $id . $key;


### PR DESCRIPTION
This PR makes retreival URLs much more clean by removing special characters like `#`, `-`, and `_` that might break hyperlinks in some messaging applications.

To accomplish this, we removed the `base64_encode_mod()` and `base64_decode_mod()` functions and instead relied on `sha256` to generate URL-safe values -- without the need to encode them before adding them to the URL's `k` parameter. Where needed, the pure PHP implementation of `base64_encode()` and `base64_decode()` are used.