### PR TITLE
Show custom error when secret length too long

### DIFF
--- a/index.php
+++ b/index.php
@@ -67,7 +67,7 @@
 		global $settings;
 
 		# verify secret length isnt too long
-		if ( strlen($_POST['secret']) > $settings['max_secret_length'] ) { throw new exception("Input length too long"); }
+		if ( strlen($_POST['secret']) > $settings['max_secret_length'] ) { throw new exception($settings['messages']['error_secret_too_long']); }
 
 		$message = store_secret($_POST['secret'], $settings);
 


### PR DESCRIPTION
Thanks @pgrungi for pointing out this bug.

The setting `error_secret_too_long` was never actually being used. This PR uses the value of that secret for the error message displayed when the input text is too long.