### PR TITLE
Fix character length validation

### DIFF
--- a/index.php
+++ b/index.php
@@ -67,7 +67,10 @@
 		global $settings;
 
 		# verify secret length isnt too long
-		if ( strlen($_POST['secret']) > $settings['max_secret_length'] ) { throw new exception($settings['messages']['error_secret_too_long']); }
+		# newlines are always \r\n, so replace with \n so the strlen count is accurate
+		if ( strlen(str_replace("\r\n", "\n", $_POST['secret'])) > $settings['max_secret_length'] ) {
+			throw new exception($settings['messages']['error_secret_too_long']);
+		}
 
 		$message = store_secret($_POST['secret'], $settings);
 


### PR DESCRIPTION
Despite being on a Unix-based OS, browsers seem to always use `\r\n` for the newline character in forms. Browsers count these characters as a single character when using the `maxlength` attribute on `<textareas>` fields. However, the [server-side validation](https://github.com/AndrewPaglusch/FlashPaper/blob/385079abe0ab60de04252ebe48370a8e9b7b6621/index.php#L70) counts `\r\n` as two characters.

This can result in edge-cases where a user is _allowed_ (client-side) to enter a secret with a length greater than the max length as defined in the `max_secret_length` setting.

This PR replaces `\r\n` with `\n` in the secret text before counting the character length for validation purposes. This does not make any changes to line endings of the submitted secret. Thank you to @pgrungi for bringing this bug to my attention!

Resolves: #62