### PR TITLE
Create a simple CI + dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "docker" # See documentation for possible values
+    directory: "/docker" # Location of package manifests
+    schedule:
+      interval: "daily"
+      timezone: "US/Central"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      timezone: "US/Central"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,29 @@
+name: Docker build CI
+
+on:
+  push:
+    paths:
+      - docker/Dockerfile
+  pull_request:
+    paths:
+      - docker/Dockerfile
+  workflow_dispatch:
+
+jobs:
+   build:
+    runs-on: ubuntu-latest
+    name: Set up Docker
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: docker/Dockerfile
+          pull: false
+          push: false

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.15
 
 RUN apk add --no-cache gettext curl nginx php7 php7-fpm php7-opcache php7-pdo php7-pdo_sqlite php7-openssl && \
     mkdir /var/www/html


### PR DESCRIPTION
To make management easier, implement dependabot + create a basic docker CI to run against any PR's.

Also pin alpine version to allow for Dependabot to do version updates. 