### PR TITLE
Fix typo in env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       MESSAGES_CONFIRM_VIEW_SECRET_HEADER: "View this secret?"
       MESSAGES_CONFIRM_VIEW_SECRET_BUTTON: "View Secret"
       MESSAGES_VIEW_SECRET_HEADER: "Self-Destructing Message"
-      MESSAGES_VIEW_SECRET_HEADER: "This message has been destroyed"
+      MESSAGES_VIEW_SECRET_SUBHEADER: "This message has been destroyed"
       PRUNE_ENABLED: "true"
       PRUNE_MIN_DAYS: 365
       PRUNE_MAX_DAYS: 730


### PR DESCRIPTION
This fixes a small typo in an environment variable name in the `docker-compose.yml` file.