### PR TITLE
Dynamically add current year in header

### DIFF
--- a/html/header.php
+++ b/html/header.php
@@ -4,7 +4,7 @@
 	<head>
 		<!--
 		######################################################################################
-		# Copyright (c) 2017-2022 Andrew Paglusch                                            #
+		# Copyright (c) 2017-<?php echo date("Y"); ?> Andrew Paglusch                                            #
 		# https://raw.githubusercontent.com/AndrewPaglusch/FlashPaper/master/LICENSE         #
 		######################################################################################
 		-->


### PR DESCRIPTION
Saves future management

From view source in Chrome:
![image](https://user-images.githubusercontent.com/4349962/181069484-a7ed960a-d531-4f14-beef-c4b2e0e8ba41.png)

Simple, but makes sure that even if the project is abandoned/maintenance updates/has reached logical conclusion, that this small part is automated.

Apologies if this is outside of scope. 