### PR TITLE
Add ability to get JSON data containing URL

### DIFF
--- a/html/json_view_code.php
+++ b/html/json_view_code.php
@@ -1,7 +1,0 @@
-<?php
-	defined('_DIRECT_ACCESS_CHECK') or exit();
-	$data = array("url" => $message);
-	header("Content-Type: application/json");
-	echo json_encode($data);
-	exit();
-?>

--- a/html/json_view_code.php
+++ b/html/json_view_code.php
@@ -1,5 +1,5 @@
-<?php 
-	defined('_DIRECT_ACCESS_CHECK') or exit(); 
+<?php
+	defined('_DIRECT_ACCESS_CHECK') or exit();
 	$data = array("url" => $message);
 	header("Content-Type: application/json");
 	echo json_encode($data);

--- a/html/json_view_code.php
+++ b/html/json_view_code.php
@@ -1,0 +1,7 @@
+<?php 
+	defined('_DIRECT_ACCESS_CHECK') or exit(); 
+	$data = array("url" => $message);
+	header("Content-Type: application/json");
+	echo json_encode($data);
+	exit();
+?>

--- a/index.php
+++ b/index.php
@@ -18,7 +18,7 @@
 
 	} elseif (isset($_POST['submit']) && !empty($_POST['secret'])) {
 		try {
-			display_secret_code(!empty($_POST['json']); # secret submitted. display url/code
+			display_secret_code($_POST['json']); # secret submitted. display url/code
 		} catch (Exception $e) { display_error($e); }
 
 	} else {

--- a/index.php
+++ b/index.php
@@ -18,7 +18,7 @@
 
 	} elseif (isset($_POST['submit']) && !empty($_POST['secret'])) {
 		try {
-			display_secret_code(); # secret submitted. display url/code
+			display_secret_code(!empty($_POST['json']); # secret submitted. display url/code
 		} catch (Exception $e) { display_error($e); }
 
 	} else {
@@ -63,7 +63,7 @@
 		require_once('html/view_secret.php');
 	}
 
-	function display_secret_code() {
+	function display_secret_code($json) {
 		global $settings;
 
 		# verify secret length isnt too long
@@ -76,6 +76,9 @@
 
 		if ($settings['return_full_url'] == true) {
 			$message = build_url($message);
+		}
+		if ($json) {
+			require_once('html/json_view_code.php');
 		}
 		require_once('html/view_code.php');
 	}

--- a/index.php
+++ b/index.php
@@ -18,7 +18,7 @@
 
 	} elseif (isset($_POST['submit']) && !empty($_POST['secret'])) {
 		try {
-			display_secret_code($_POST['json']); # secret submitted. display url/code
+			display_secret_code(!empty($_POST['json'])); # secret submitted. display url/code
 		} catch (Exception $e) { display_error($e); }
 
 	} else {
@@ -79,8 +79,9 @@
 		}
 		if ($json) {
 			require_once('html/json_view_code.php');
-		}
-		require_once('html/view_code.php');
+		} else {
+		    require_once('html/view_code.php');
+        }
 	}
 
 	function build_url($k) {

--- a/index.php
+++ b/index.php
@@ -85,7 +85,7 @@
 		}
 
 		if ($return_only_json) {
-			return json_encode(array("url" => $message));
+			return json_encode(array("url" => $message), JSON_UNESCAPED_SLASHES);
 		}
 
 		require_once('html/view_code.php');

--- a/index.php
+++ b/index.php
@@ -4,12 +4,13 @@
 	require_once("settings.php"); # load settings
 	require_once("includes/functions.php"); # load functions
 
-	$json = !empty($_POST['json']))
-
-	if (!$json) {
-		require_once('html/header.php'); # display header if not JSON
+	# display secret code in json format if requested
+	if (isset($_POST['json']) && isset($_POST['submit']) && !empty($_POST['secret'])) {
+		header("Content-Type: application/json");
+		die(display_secret_code(true));
 	}
 
+	require_once('html/header.php'); # display header
 
 	if (!empty($_GET['k'])) {
 		try {
@@ -41,9 +42,7 @@
 		} catch (Exception $e) { display_error($e); }
 	}
 
-	if (!$json) {
-		require_once('html/footer.php'); # display footer
-	}
+	require_once('html/footer.php'); # display footer
 
 	function display_form() {
 		global $settings;
@@ -70,7 +69,7 @@
 		require_once('html/view_secret.php');
 	}
 
-	function display_secret_code($json) {
+	function display_secret_code($return_only_json = false) {
 		global $settings;
 
 		# verify secret length isnt too long
@@ -84,11 +83,12 @@
 		if ($settings['return_full_url'] == true) {
 			$message = build_url($message);
 		}
-		if ($json) {
-			require_once('html/json_view_code.php');
-		} else {
-		    require_once('html/view_code.php');
-        }
+
+		if ($return_only_json) {
+			return json_encode(array("url" => $message));
+		}
+
+		require_once('html/view_code.php');
 	}
 
 	function build_url($k) {

--- a/index.php
+++ b/index.php
@@ -3,7 +3,12 @@
 	require_once("includes/sanitycheck.php"); # check everything before we proceed
 	require_once("settings.php"); # load settings
 	require_once("includes/functions.php"); # load functions
-	require_once('html/header.php'); # display header
+
+	$json = !empty($_POST['json']))
+
+	if (!$json) {
+		require_once('html/header.php'); # display header if not JSON
+	}
 
 
 	if (!empty($_GET['k'])) {
@@ -18,7 +23,7 @@
 
 	} elseif (isset($_POST['submit']) && !empty($_POST['secret'])) {
 		try {
-			display_secret_code(!empty($_POST['json'])); # secret submitted. display url/code
+			display_secret_code($json); # secret submitted. display url/code
 		} catch (Exception $e) { display_error($e); }
 
 	} else {
@@ -36,7 +41,9 @@
 		} catch (Exception $e) { display_error($e); }
 	}
 
-	require_once('html/footer.php'); # display footer
+	if (!$json) {
+		require_once('html/footer.php'); # display footer
+	}
 
 	function display_form() {
 		global $settings;


### PR DESCRIPTION
This adds a simple page that returns `$message` in the JSON format `{ "url": "<generated_url>" }`

Resolves #85 

Example of use:

```
curl -s -X POST -d "secret=<secret>&json=true&submit=" https://<flashpaper>/
```