### PR TITLE
Add base_url Setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ https://flashpaper.io
  - `enabled`: Turn on/off auto-pruning of old secrets from the database upon page load
  - `min_days`/`max_days`: When a secret is submitted, a random date/time is generated between `min_days` and `max_days` in the future. After that date/time has elapsed, the secret will be pruned from the database if `enabled` is set to `true`. This is to prevent your database from being filled with secrets that are never retrieved. NOTE: Even if `enabled` is set to `false`, the prune value will still be generated and stored in the database, but secrets will not be pruned unless `enabled` is switched to `true`.
 
-## `base_url`:
+### `base_url`:
 FlashPaper will try to generate the secret retrieval URL based on information provided by the upstream webserver. This process isn't always 100% accurate. If the secret retrieval URL that FlashPaper creates isn't correct for your setup (this usually happens when you're using a reverse proxy upstream), you can manually specify the URL that FlashPaper will use. For example: A `base_url` of "https://foo.com/flashpaper" will result in retrieval URLs like "https://foo.com/flashpaper/?k=xxxxxxxxxxxxx".
 
 ## Donations

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ https://flashpaper.io
  - `enabled`: Turn on/off auto-pruning of old secrets from the database upon page load
  - `min_days`/`max_days`: When a secret is submitted, a random date/time is generated between `min_days` and `max_days` in the future. After that date/time has elapsed, the secret will be pruned from the database if `enabled` is set to `true`. This is to prevent your database from being filled with secrets that are never retrieved. NOTE: Even if `enabled` is set to `false`, the prune value will still be generated and stored in the database, but secrets will not be pruned unless `enabled` is switched to `true`.
 
+## `base_url`:
+FlashPaper will try to generate the secret retrieval URL based on information provided by the upstream webserver. This process isn't always 100% accurate. If the secret retrieval URL that FlashPaper creates isn't correct for your setup (this usually happens when you're using a reverse proxy upstream), you can manually specify the URL that FlashPaper will use. For example: A `base_url` of "https://foo.com/flashpaper" will result in retrieval URLs like "https://foo.com/flashpaper/?k=xxxxxxxxxxxxx".
+
 ## Donations
 
 PayPal: https://paypal.me/AndrewPaglusch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     environment:
       SITE_TITLE: "FlashPaper :: Self-Destructing Message"
       RETURN_FULL_URL: "true"
+      BASE_URL: ""
       MAX_SECRET_LENGTH: "3000"
       ANNOUNCEMENT: ""
       MESSAGES_ERROR_SECRET_TOO_LONG: "Input length too long"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,6 +4,7 @@
 
 [ -z "$SITE_TITLE" ] && export SITE_TITLE="FlashPaper :: Self-Destructing Message"
 [ -z "$RETURN_FULL_URL" ] && export RETURN_FULL_URL="true"
+[ -z "$BASE_URL" ] && export BASE_URL=""
 [ -z "$MAX_SECRET_LENGTH" ] && export MAX_SECRET_LENGTH="3000"
 [ -z "$MESSAGES_ERROR_SECRET_TOO_LONG" ] && export MESSAGES_ERROR_SECRET_TOO_LONG="Input length too long"
 [ -z "$MESSAGES_SUBMIT_SECRET_HEADER" ] && export MESSAGES_SUBMIT_SECRET_HEADER="Create A Self-Destructing Message"

--- a/docker/settings.php.TEMPLATE
+++ b/docker/settings.php.TEMPLATE
@@ -4,6 +4,7 @@
 	${DOLLAR}settings = [
 		"site_title" => "${SITE_TITLE}",
 		"return_full_url" => ${RETURN_FULL_URL},
+		"base_url" => "${BASE_URL}",
 		"max_secret_length" => ${MAX_SECRET_LENGTH},
 		"announcement" => "${ANNOUNCEMENT}",
 		'prune' => [

--- a/index.php
+++ b/index.php
@@ -81,6 +81,17 @@
 	}
 
 	function build_url($k) {
+		global $settings;
+
+		# use the base_url value from settings if it's there
+		if ( !empty($settings['base_url']) ) {
+			$base_url = $settings['base_url'];
+			$base_url = str_replace("index.php", "", $base_url); # remove index.php from base_url if it's there
+			$base_url = rtrim($base_url, '/') . '/'; # make sure base_url ends with a '/'
+			return $base_url . "?k=${k}";
+		}
+
+		# try our best to predict the base url of the FlashPaper instance
 		$scheme = (isset($_SERVER['REQUEST_SCHEME'])) ? $_SERVER['REQUEST_SCHEME'] . '://' : 'https://';
 		$hostname = $_SERVER['HTTP_HOST']; # my.flashpaper.io
 		$path = strtok($_SERVER['REQUEST_URI'], '?'); # strip any GET vars from url (like ?t=bla)
@@ -89,7 +100,6 @@
 		$path = rtrim($path, '/') . '/'; # make sure path ends with /
 		$args = "?k=${k}"; # /?k=a1b2c3d4...
 		return "${scheme}${hostname}${path}${args}";
-
 	}
 
 	function display_error($exception) {

--- a/settings.example.php
+++ b/settings.example.php
@@ -4,6 +4,7 @@
 	$settings = [
 		'site_title' => 'FlashPaper :: Self-Destructing Message',
 		'return_full_url' => true,
+		'base_url' => '', # https://mydomain.com/flashpaper
 		'max_secret_length' => 3000,
 		'announcement' => '',
 		'prune' => [


### PR DESCRIPTION
In some cases (#60 #94), FlashPaper can't figure out how to correctly build the secret retrieval URL. The `base_url` setting allows the administrator to specify a static string to be used instead.