### PR TITLE
Simplify API Submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ https://flashpaper.io
   7. Entry deleted from DB
   8. Decrypted text sent to user
 
+## Submitting Secrets via the API (with `curl`)
+
+FlashPaper can accept secret submissions through a simple API. The retrieval URL will be returned in a JSON object. The 
+
+Here's what it looks like to submit a secret with `curl`:
+```
+$ curl -s -X POST -d "secret=my secret&json=true" https://flashpaper.io
+{"url":"https://flashpaper.io/?k=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}
+```
+
 ## Settings
 
 ### `prune`:

--- a/index.php
+++ b/index.php
@@ -4,8 +4,8 @@
 	require_once("settings.php"); # load settings
 	require_once("includes/functions.php"); # load functions
 
-	# display secret code in json format if requested
-	if (isset($_POST['json']) && isset($_POST['submit']) && !empty($_POST['secret'])) {
+	# display secret retrieval url in json format if requested
+	if (isset($_POST['json']) && !empty($_POST['secret'])) {
 		header("Content-Type: application/json");
 		die(display_secret_code(true));
 	}


### PR DESCRIPTION
This removes the need for `submit` to be set when calling the API
The README is also updated with API instructions