### PR TITLE
Add arm dockerfile and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,18 @@ https://flashpaper.io
   3. Run `docker-compose up -d` to start FlashPaper
   4. Set up a reverse-proxy in front of FlashPaper that terminates SSL/TLS
 
-#### Building an image
+#### Building an Image
   You can build your own image using the provided Dockerfile in the `docker/` folder. There are currently two:
-  - For intel
-  - For ARM 64 bit
-  In order to build, move the appropriate Dockerfile to the root of the repo, and either run `docker build . -t flashpaper -f arm.Dockerfile` for example, or
-  include it in your docker-compose:
+  - For x86_64 (docker/Dockerfile)
+  - For ARM64 (docker/arm.Dockerfile)
+  In order to build FlashPaper, run `docker build . -t flashpaper -f docker/Dockerfile`. If you would like to build FlashPaper for a different CPU architecture, replace `docker/Dockerfile` with the appropriate Dockerfile.
+  You can also build via docker-compose by replacing the `image:` line in (docker-compose.yml)[https://github.com/AndrewPaglusch/FlashPaper/blob/master/docker-compose.yml] with the following (make sure to choose the Dockerfile for your architecture):
+  
   ```
   build:
       context: .
-      dockerfile: ./arm.Dockerfile
+      dockerfile: docker/Dockerfile
   ```
-  - You may omit the `image: <image_name>` line if building as it will use the built image by default.
-  You can now run `docker compose up --build` optionally followed by `docker compose logs --follow`.
 
 ### Traditional
   **Requirements:** PHP 7.0+ and a web server

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ https://flashpaper.io
   You can build your own image using the provided Dockerfile in the `docker/` folder. There are currently two:
   - For x86_64 (`docker/Dockerfile`)
   - For ARM64 (`docker/arm.Dockerfile`)
+
   In order to build FlashPaper, run `docker build . -t flashpaper -f docker/Dockerfile`. If you would like to build FlashPaper for a different CPU architecture, replace `docker/Dockerfile` with the appropriate Dockerfile.
-  You can also build via docker-compose by replacing the `image:` line in (docker-compose.yml)[https://github.com/AndrewPaglusch/FlashPaper/blob/master/docker-compose.yml] with the following (make sure to choose the Dockerfile for your architecture):
+  You can also build via docker-compose by replacing the `image:` line in [docker-compose.yml](https://github.com/AndrewPaglusch/FlashPaper/blob/master/docker-compose.yml) with the following (make sure to choose the Dockerfile for your architecture):
   
   ```
   build:

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ https://flashpaper.io
 
 #### Building an Image
   You can build your own image using the provided Dockerfile in the `docker/` folder. There are currently two:
-  - For x86_64 (docker/Dockerfile)
-  - For ARM64 (docker/arm.Dockerfile)
+  - For x86_64 (`docker/Dockerfile`)
+  - For ARM64 (`docker/arm.Dockerfile`)
   In order to build FlashPaper, run `docker build . -t flashpaper -f docker/Dockerfile`. If you would like to build FlashPaper for a different CPU architecture, replace `docker/Dockerfile` with the appropriate Dockerfile.
   You can also build via docker-compose by replacing the `image:` line in (docker-compose.yml)[https://github.com/AndrewPaglusch/FlashPaper/blob/master/docker-compose.yml] with the following (make sure to choose the Dockerfile for your architecture):
   

--- a/README.md
+++ b/README.md
@@ -18,6 +18,20 @@ https://flashpaper.io
   3. Run `docker-compose up -d` to start FlashPaper
   4. Set up a reverse-proxy in front of FlashPaper that terminates SSL/TLS
 
+#### Building an image
+  You can build your own image using the provided Dockerfile in the `docker/` folder. There are currently two:
+  - For intel
+  - For ARM 64 bit
+  In order to build, move the appropriate Dockerfile to the root of the repo, and either run `docker build . -t flashpaper -f arm.Dockerfile` for example, or
+  include it in your docker-compose:
+  ```
+  build:
+      context: .
+      dockerfile: ./arm.Dockerfile
+  ```
+  - You may omit the `image: <image_name>` line if building as it will use the built image by default.
+  You can now run `docker compose up --build` optionally followed by `docker compose logs --follow`.
+
 ### Traditional
   **Requirements:** PHP 7.0+ and a web server
   1. Download and extract the [latest release](https://github.com/AndrewPaglusch/FlashPaper/releases/latest) of FlashPaper to the document root of your web server

--- a/docker/arm.Dockerfile
+++ b/docker/arm.Dockerfile
@@ -1,0 +1,20 @@
+FROM arm64v8/alpine:3.16.2
+
+RUN apk add --no-cache gettext curl nginx php8 php8-fpm php8-opcache php8-pdo php8-pdo_sqlite php8-openssl && \
+    mkdir /var/www/html
+
+COPY . /var/www/html
+
+RUN chmod -R 775 /var/www/html && \
+    chown -R nginx:nginx /var/www/html
+
+COPY docker/php-fpm.conf /etc/php8/php-fpm.conf
+COPY docker/nginx.conf /etc/nginx/nginx.conf
+COPY docker/entrypoint.sh /entrypoint.sh
+
+RUN mkdir -p /var/run/nginx && \
+    mkdir -p /var/run/php-fpm && \
+    chown -R nginx:nginx /var/run/ && \
+    chmod +x /entrypoint.sh
+VOLUME /var/www/html/data
+ENTRYPOINT ["/bin/ash", "/entrypoint.sh"]

--- a/docker/arm.Dockerfile
+++ b/docker/arm.Dockerfile
@@ -1,6 +1,11 @@
 FROM arm64v8/alpine:3.17.2
 
-RUN apk add --no-cache gettext curl nginx php81 php81-fpm php81-opcache php81-pdo php81-pdo_sqlite php81-openssl && \
+# To reduce duplication
+ENV PHP_VER=php81
+# For use in entrypoint.sh
+ENV PHPFPM_VER=php-fpm81
+
+RUN apk add --no-cache gettext curl nginx $PHP_VER $PHP_VER-fpm $PHP_VER-opcache $PHP_VER-pdo $PHP_VER-pdo_sqlite $PHP_VER-openssl && \
     mkdir /var/www/html
 
 COPY . /var/www/html
@@ -8,7 +13,7 @@ COPY . /var/www/html
 RUN chmod -R 775 /var/www/html && \
     chown -R nginx:nginx /var/www/html
 
-COPY docker/php-fpm.conf /etc/php81/php-fpm.conf
+COPY docker/php-fpm.conf /etc/$PHP_VER/php-fpm.conf
 COPY docker/nginx.conf /etc/nginx/nginx.conf
 COPY docker/entrypoint.sh /entrypoint.sh
 
@@ -17,4 +22,5 @@ RUN mkdir -p /var/run/nginx && \
     chown -R nginx:nginx /var/run/ && \
     chmod +x /entrypoint.sh
 VOLUME /var/www/html/data
+
 ENTRYPOINT ["/bin/ash", "/entrypoint.sh"]

--- a/docker/arm.Dockerfile
+++ b/docker/arm.Dockerfile
@@ -1,6 +1,6 @@
-FROM arm64v8/alpine:3.16.2
+FROM arm64v8/alpine:3.17.2
 
-RUN apk add --no-cache gettext curl nginx php8 php8-fpm php8-opcache php8-pdo php8-pdo_sqlite php8-openssl && \
+RUN apk add --no-cache gettext curl nginx php81 php81-fpm php81-opcache php81-pdo php81-pdo_sqlite php81-openssl && \
     mkdir /var/www/html
 
 COPY . /var/www/html
@@ -8,7 +8,7 @@ COPY . /var/www/html
 RUN chmod -R 775 /var/www/html && \
     chown -R nginx:nginx /var/www/html
 
-COPY docker/php-fpm.conf /etc/php8/php-fpm.conf
+COPY docker/php-fpm.conf /etc/php81/php-fpm.conf
 COPY docker/nginx.conf /etc/nginx/nginx.conf
 COPY docker/entrypoint.sh /entrypoint.sh
 

--- a/docker/arm.Dockerfile
+++ b/docker/arm.Dockerfile
@@ -2,8 +2,6 @@ FROM arm64v8/alpine:3.17.2
 
 # To reduce duplication
 ENV PHP_VER=php81
-# For use in entrypoint.sh
-ENV PHPFPM_VER=php-fpm81
 
 RUN apk add --no-cache gettext curl nginx $PHP_VER $PHP_VER-fpm $PHP_VER-opcache $PHP_VER-pdo $PHP_VER-pdo_sqlite $PHP_VER-openssl && \
     mkdir /var/www/html


### PR DESCRIPTION
I needed to run it on my Raspberry Pi, so I created a new Dockerfile that uses the ARM version of the alpine image. I also had to learn how to properly build it, so I added it to the readme.

Alternatively, a new ARM docker image could be created with the `arm64v8` tag and uploaded to docker hub and then all the user would have to do is modify their docker-compose file to pull that image instead. README would reflect that. If that route is taken then this PR can be closed.