### PR TITLE
Infinite database creation

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -25,7 +25,7 @@
 		$results = glob("./data/*--{$dbName}");
 
 		# find name of existing db or generate a new one if not found
-		if ( count($results) != 1 ) {
+		if ( count($results) < 1 ) {
 			$prefix = crypto_rand_string(32);
 			$dbName = "./data/{$prefix}--{$dbName}";
 		} else {


### PR DESCRIPTION
This is a bug fix. If, for some reason, multiple .sqlite files are generated, the creation pattern will render the application unusable since a new database is created every time it connects. This bug can be triggered by having jitter on the volumes in kubernetes.